### PR TITLE
Skip directories when finding secrets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "docker-secret",
       "version": "1.2.3",
       "license": "MIT",
       "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export function getSecrets<T extends Secrets = Secrets>(secretDir?: string): T {
     files.forEach((file) => {
       const fullPath = path.join(_secretDir, file);
       const key = file;
+      if(fs.lstatSync(fullPath).isDirectory()) return;
       const data = fs.readFileSync(fullPath, "utf8").toString().trim();
 
       secrets[key] = data;


### PR DESCRIPTION
Kubernetes auto-mounts a directory in the /run/secrets, causing an error when this library is used. This commit aims to resolve that by skipping over any directory in /run/secrets.

Related issue: pawelmalak/flame#242